### PR TITLE
Added some explanation to the /create page

### DIFF
--- a/views/userCreate.handlebars
+++ b/views/userCreate.handlebars
@@ -2,6 +2,9 @@
   <div class="row">
     <div class="col-md-8" class="form-group">
       <div class="row">
+        <h3>Florida Man...</h3>
+        <br>
+        <p>Of course, every Florida Man article begins with the words 'Florida Man...' -- so don't bother putting it in. We'll add the phrase to the beginning of every headline submitted.</p>
         <input class="new-item form-control" id="userHeadline" placeholder="WRITE YOUR OWN HEADLINE HERE" type="text" />
       </div>
       <br>


### PR DESCRIPTION
This is just a small modification -- there's now a little note on the Create page explaining that the user shouldn't add 'Florida Man' to their headline, that we'll add it in there